### PR TITLE
Fix "invalid index of a 0-dim tensor. Use tensor.item() to convert a …

### DIFF
--- a/NeuralStyleTransfer.py
+++ b/NeuralStyleTransfer.py
@@ -9,6 +9,7 @@ from sys import argv
 import torchvision.transforms as transforms
 import copy
 import librosa
+import soundfile as sf
 
 class CNNModel(nn.Module):
 		def __init__(self):
@@ -224,6 +225,6 @@ if __name__ == '__main__':
 		p = np.angle(librosa.stft(x, N_FFT))
 
 	OUTPUT_FILENAME = 'output1D_4096_iter'+str(num_steps)+'_c'+content_audio_name+'_s'+style_audio_name+'_sw'+str(style_weight)+'_k3s1p1.wav'
-	librosa.output.write_wav(OUTPUT_FILENAME, x, style_sr)
+	sf.write(OUTPUT_FILENAME, x, style_sr)
 
 	print('DONE...')

--- a/NeuralStyleTransfer.py
+++ b/NeuralStyleTransfer.py
@@ -95,9 +95,11 @@ if __name__ == '__main__':
 	if torch.cuda.is_available():
 		style_float = Variable((torch.from_numpy(style_audio)).cuda())
 		content_float = Variable((torch.from_numpy(content_audio)).cuda())	
+		print('using CUDA')
 	else:
 		style_float = Variable(torch.from_numpy(style_audio))
 		content_float = Variable(torch.from_numpy(content_audio))
+		print('using CPU')
 	#style_float = style_float.unsqueeze(0)
 	
 	#style_float = style_float.view([1025,1,2500])
@@ -190,7 +192,7 @@ if __name__ == '__main__':
 				run[0] += 1
 				if run[0] % 100 == 0:
 					print("run {}:".format(run))
-					print('Style Loss : {:8f}'.format(style_score.data[0])) #CHANGE 4->8 
+					print('Style Loss : {:8f}'.format(style_score.item())) #CHANGE 4->8 
 					print()
 
 				return style_score


### PR DESCRIPTION
…0-dim tensor to a Python number" error on line 193 and add some output to inform if GPU was detected.

Newer version of torch does not like the syntax for accessing the style_score. This fix should be backward compatible. 
Also added a simple print() statement to inform if cuda detection was successful or if app will run on cpu.